### PR TITLE
reset full hooks state on signature change

### DIFF
--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,3 +1,6 @@
 export const VNODE_COMPONENT = '__c';
 export const DIFFED_OPTION = '__b';
 export const NAMESPACE = '__PREFRESH__';
+export const COMPONENT_HOOKS = '__H';
+export const HOOKS_LIST = '__';
+export const EFFECTS_LIST = '__h';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -4,7 +4,13 @@ import './runtime/diffed';
 import './runtime/unmount';
 
 import { Component } from 'preact';
-import { VNODE_COMPONENT, NAMESPACE } from './constants';
+import {
+	VNODE_COMPONENT,
+	NAMESPACE,
+	HOOKS_LIST,
+	EFFECTS_LIST,
+	COMPONENT_HOOKS
+} from './constants';
 import { vnodesForComponent } from './runtime/vnodesForComponent';
 
 const signaturesForType = new WeakMap();
@@ -58,7 +64,7 @@ function sign(type, key, forceReset, getCustomHooks, status) {
 	}
 }
 
-function replaceComponent(OldType, NewType) {
+function replaceComponent(OldType, NewType, resetHookState) {
 	const vnodes = vnodesForComponent.get(OldType);
 	if (!vnodes) return;
 
@@ -107,6 +113,13 @@ function replaceComponent(OldType, NewType) {
 				}
 			} catch (e) {
 				/* Functional component */
+			}
+
+			if (resetHookState) {
+				vnode[VNODE_COMPONENT][COMPONENT_HOOKS] = {
+					[HOOKS_LIST]: [],
+					[EFFECTS_LIST]: []
+				};
 			}
 
 			Component.prototype.forceUpdate.call(vnode[VNODE_COMPONENT]);

--- a/packages/webpack/src/createTemplate.js
+++ b/packages/webpack/src/createTemplate.js
@@ -63,14 +63,18 @@ if (module.hot && shouldBind) {
               prevSignature.key !== nextSignature.key ||
               nextSignature.forceReset
             ) {
-              window.location.reload();
+              if (typeof i === 'string' && i.startsWith('use') && i[3] == i[3].toUpperCase()) {
+                window.location.reload();
+              } else {
+                self.${NAMESPACE}.replaceComponent(m.exports[i], fn, true);
+              }
+            } else {
+              self.${NAMESPACE}.replaceComponent(m.exports[i], fn, false);
             }
 
-            self.${NAMESPACE}.replaceComponent(m.exports[i], fn);
           }
         }
       } catch (e) {
-        console.log(e);
         self.location.reload();
       }
     }


### PR DESCRIPTION
Instead of doing a full page reload we can reset the hooks state on the corresponding vnodes, this however does not solve the case of custom-hooks yet.